### PR TITLE
Audio: Use std::deque instead of std::vector for the audio buffer typ…

### DIFF
--- a/src/audio_core/codec.cpp
+++ b/src/audio_core/codec.cpp
@@ -117,7 +117,9 @@ StereoBuffer16 DecodePCM16(const unsigned num_channels, const u8* const data,
             ret[i].fill(sample);
         }
     } else {
-        std::memcpy(ret.data(), data, sample_count * 2 * sizeof(u16));
+        for (size_t i = 0; i < sample_count; ++i) {
+            std::memcpy(&ret[i], data + i * sizeof(s16) * 2, 2 * sizeof(s16));
+        }
     }
 
     return ret;

--- a/src/audio_core/codec.h
+++ b/src/audio_core/codec.h
@@ -5,13 +5,13 @@
 #pragma once
 
 #include <array>
-#include <vector>
+#include <deque>
 #include "common/common_types.h"
 
 namespace Codec {
 
 /// A variable length buffer of signed PCM16 stereo samples.
-using StereoBuffer16 = std::vector<std::array<s16, 2>>;
+using StereoBuffer16 = std::deque<std::array<s16, 2>>;
 
 /// See: Codec::DecodeADPCM
 struct ADPCMState {

--- a/src/audio_core/hle/source.h
+++ b/src/audio_core/hle/source.h
@@ -108,7 +108,7 @@ private:
 
         u32 current_sample_number = 0;
         u32 next_sample_number = 0;
-        std::vector<std::array<s16, 2>> current_buffer;
+        AudioInterp::StereoBuffer16 current_buffer;
 
         // buffer_id state
 

--- a/src/audio_core/interpolate.cpp
+++ b/src/audio_core/interpolate.cpp
@@ -47,7 +47,7 @@ static void StepOverSamples(State& state, StereoBuffer16& input, float rate,
     state.xn1 = input[inputi + 1];
     state.fposition = fposition - inputi * scale_factor;
 
-    input.erase(input.begin(), input.begin() + inputi + 2);
+    input.erase(input.begin(), std::next(input.begin(), inputi + 2));
 }
 
 void None(State& state, StereoBuffer16& input, float rate, DSP::HLE::StereoFrame16& output,

--- a/src/audio_core/interpolate.h
+++ b/src/audio_core/interpolate.h
@@ -5,14 +5,14 @@
 #pragma once
 
 #include <array>
-#include <vector>
+#include <deque>
 #include "audio_core/hle/common.h"
 #include "common/common_types.h"
 
 namespace AudioInterp {
 
 /// A variable length buffer of signed PCM16 stereo samples.
-using StereoBuffer16 = std::vector<std::array<s16, 2>>;
+using StereoBuffer16 = std::deque<std::array<s16, 2>>;
 
 struct State {
     /// Two historical samples.


### PR DESCRIPTION
…e (StereoBuffer16).

The current code inserts and deletes elements from the beginning of the audio buffer, which is very inefficient in an std::vector.

Profiling was done using VisualStudio2017's Performance Analyzer in Super Mario 3D Land.

Before this change: AudioInterp::Linear had 14.14% of the runtime (inclusive) and most of that time was spent in std::vector's insert implementation.
After this change: AudioInterp::Linear has 0.36% of the runtime (inclusive)