### PR TITLE
Kernel/Sessions: Wake up any threads waiting on a ServerSession when …

### DIFF
--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -47,8 +47,13 @@ bool ServerSession::ShouldWait(Thread* thread) const {
 
 void ServerSession::Acquire(Thread* thread) {
     ASSERT_MSG(!ShouldWait(thread), "object unavailable!");
+
+    // If the client endpoint was closed, don't do anything. This ServerSession is now useless and
+    // will linger until its last handle is closed by the running application.
+    if (parent->client == nullptr)
+        return;
+
     // We are now handling a request, pop it from the stack.
-    // TODO(Subv): What happens if the client endpoint is closed before any requests are made?
     ASSERT(!pending_requesting_threads.empty());
     currently_handling = pending_requesting_threads.back();
     pending_requesting_threads.pop_back();


### PR DESCRIPTION
…its client is closed

The error code 0xC920181A will be returned by svcReplyAndReceive when the wakeup callback runs.
This lets LLE services be properly notified of clients closing the connection so they can end their handler threads instead of letting them linger indefinitely, taking up connection slots in their parent port.