### PR TITLE
vector_math: Return by const reference for const operator[]

### DIFF
--- a/src/common/vector_math.h
+++ b/src/common/vector_math.h
@@ -131,7 +131,7 @@ public:
     {
         return *((&x) + i);
     }
-    T operator[](const int i) const {
+    const T& operator[](const int i) const {
         return *((&x) + i);
     }
 
@@ -288,7 +288,7 @@ public:
     {
         return *((&x) + i);
     }
-    T operator[](const int i) const {
+    const T& operator[](const int i) const {
         return *((&x) + i);
     }
 
@@ -502,7 +502,7 @@ public:
     {
         return *((&x) + i);
     }
-    T operator[](const int i) const {
+    const T& operator[](const int i) const {
         return *((&x) + i);
     }
 


### PR DESCRIPTION
Makes behavior between both overloads consistent.