### PR TITLE
HLE/FS: Stubbed GetNumSeeds to always return 0 seeds.

### DIFF
--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -968,6 +968,26 @@ static void GetProgramLaunchInfo(Service::Interface* self) {
     rb.Push<u32>(0);
 }
 
+/**
+ * FS_User::GetNumSeeds service function.
+ *  Inputs:
+ *      0 : 0x087D0000
+ *  Outputs:
+ *      0 : 0x087D0080
+ *      1 : Result of function, 0 on success, otherwise error code
+ *      2 : Number of seeds in the SEEDDB
+ */
+static void GetNumSeeds(Service::Interface* self) {
+    IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x87D, 0, 0);
+
+    LOG_WARNING(Service_FS, "(STUBBED) called");
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
+
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(0);
+}
+
 const Interface::FunctionInfo FunctionTable[] = {
     {0x000100C6, nullptr, "Dummy1"},
     {0x040100C4, nullptr, "Control"},
@@ -1078,6 +1098,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x08690000, nullptr, "GetNandEraseCount"},
     {0x086A0082, nullptr, "ReadNandReport"},
     {0x087A0180, nullptr, "AddSeed"},
+    {0x087D0000, GetNumSeeds, "GetNumSeeds"},
     {0x088600C0, nullptr, "CheckUpdatedDat"},
 };
 


### PR DESCRIPTION
We don't yet implement the SEEDDB store.
This number is supposed to be modified by the AddSeed function (0x087A0180) but there's too little info about it on 3dbrew.