### PR TITLE
err_f: Add missing break in ThrowFatalError()

### DIFF
--- a/src/core/hle/service/err_f.cpp
+++ b/src/core/hle/service/err_f.cpp
@@ -200,6 +200,7 @@ void ERR_F::ThrowFatalError(Kernel::HLERequestContext& ctx) {
         case ExceptionType::PrefetchAbort:
             LOG_CRITICAL(Service_ERR, "IFSR: 0x%08X", errtype.exception_data.exception_info.sr);
             LOG_CRITICAL(Service_ERR, "r15: 0x%08X", errtype.exception_data.exception_info.ar);
+            break;
         case ExceptionType::DataAbort:
             LOG_CRITICAL(Service_ERR, "DFSR: 0x%08X", errtype.exception_data.exception_info.sr);
             LOG_CRITICAL(Service_ERR, "DFAR: 0x%08X", errtype.exception_data.exception_info.ar);


### PR DESCRIPTION
Introduced by 691f069743bd0cf06cb070ee14c8e4ef51977550

If we hit a prefetch abort, the DFSR and DFAR contents aren't really going to be
that useful.