### PR TITLE
gl_rasterizer: Fix incorrect comparison against src_surface in Accele…

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1093,7 +1093,7 @@ bool RasterizerOpenGL::AccelerateTextureCopy(const GPU::Regs::DisplayTransferCon
     Surface dst_surface;
     std::tie(dst_surface, dst_rect) =
         res_cache.GetSurfaceSubRect(dst_params, ScaleMatch::Upscale, load_gap);
-    if (src_surface == nullptr) {
+    if (dst_surface == nullptr) {
         return false;
     }
 


### PR DESCRIPTION
…rateTextureCopy()

This should actually be comparing the validity of the destination
surface.