### PR TITLE
verify_login: Make VerifyLogin exceptionless

### DIFF
--- a/src/web_service/verify_login.cpp
+++ b/src/web_service/verify_login.cpp
@@ -12,15 +12,19 @@ std::future<bool> VerifyLogin(std::string& username, std::string& token,
                               const std::string& endpoint_url, std::function<void()> func) {
     auto get_func = [func, username](const std::string& reply) -> bool {
         func();
-        if (reply.empty())
+
+        if (reply.empty()) {
             return false;
-        nlohmann::json json = nlohmann::json::parse(reply);
-        std::string result;
-        try {
-            result = json["username"];
-        } catch (const nlohmann::detail::out_of_range&) {
         }
-        return result == username;
+
+        nlohmann::json json = nlohmann::json::parse(reply);
+        const auto iter = json.find("username");
+
+        if (iter == json.end()) {
+            return username.empty();
+        }
+
+        return username == *iter;
     };
     return GetJson<bool>(get_func, endpoint_url, false, username, token);
 }


### PR DESCRIPTION
This function can be simplified by attempting to find the username
within the JSON object and then only accessing it if it does. There's no
need to blindly access the data itself.

This also eliminates the need to copy the string to a local as well,
since we already have the element itself, we can just compare against
it. For the failure case, it's the same if we were checking that the
provided username string is empty.