### PR TITLE
core, citra_qt: add frame advancing to framelimiter

### DIFF
--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -114,6 +114,9 @@
     <addaction name="action_Record_Movie"/>
     <addaction name="action_Play_Movie"/>
     <addaction name="action_Stop_Recording_Playback"/>
+    <addaction name="separator"/>
+    <addaction name="action_Enable_Frame_Advancing"/>
+    <addaction name="action_Advance_Frame"/>
    </widget>
    <widget class="QMenu" name="menu_Multiplayer">
     <property name="enabled">
@@ -274,6 +277,25 @@
    </property>
    <property name="text">
     <string>Stop Recording / Playback</string>
+   </property>
+  </action>
+  <action name="action_Enable_Frame_Advancing">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Enable Frame Advancing</string>
+   </property>
+  </action>
+  <action name="action_Advance_Frame">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Advance Frame</string>
    </property>
   </action>
   <action name="action_View_Lobby">

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -4,9 +4,11 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <mutex>
 #include "common/common_types.h"
+#include "common/thread.h"
 
 namespace Core {
 
@@ -70,6 +72,14 @@ public:
 
     void DoFrameLimiting(std::chrono::microseconds current_system_time_us);
 
+    /**
+     * Sets whether frame advancing is enabled or not.
+     * Note: The frontend must cancel frame advancing before shutting down in order
+     *       to resume the emu_thread.
+     */
+    void SetFrameAdvancing(bool value);
+    void AdvanceFrame();
+
 private:
     /// Emulated system time (in microseconds) at the last limiter invocation
     std::chrono::microseconds previous_system_time_us{0};
@@ -78,6 +88,12 @@ private:
 
     /// Accumulated difference between walltime and emulated time
     std::chrono::microseconds frame_limiting_delta_err{0};
+
+    /// Whether to use frame advancing (i.e. frame by frame)
+    std::atomic_bool frame_advancing_enabled;
+
+    /// Event to advance the frame when frame advancing is enabled
+    Common::Event frame_advance_event;
 };
 
 } // namespace Core


### PR DESCRIPTION
Frame advancing is a commonly used TAS feature which basically means running the game frame by frame. TASers use this feature to press exact buttons at the exact frames. This commit added frame advancing to the framelimiter and two actions to the Movie menu. The default hotkey is `\` for advancing frames, and `Ctrl+A` for toggling frame advancing. The `Advance Frame` hotkey would automatically enable frame advancing if not already enabled.